### PR TITLE
rename base image to openjdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 
 ARG VERSION_SBT="0.13.9"


### PR DESCRIPTION
As the official java image is deprecated, we are switching to the openjdk image, which is the successor. In theory nothing should change. Let's see.

 - [x] ready for review