### PR TITLE
updating firefox to 54.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,20 +18,22 @@ RUN \
       tee /etc/apt/sources.list.d/mongodb-org-3.2.list \
   && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
-  && curl -sS https://mozilla.debian.net/archive.asc | apt-key add - \
-  && echo "deb http://mozilla.debian.net/ jessie-backports firefox-release" > /etc/apt/sources.list.d/mozilla.list \
   && apt-get update \
   && apt-get install -y \
       build-essential \
       chromium \
+      firefox-esr \
       mongodb-org-shell="${VERSION_MONGO}" \
       mongodb-org-tools="${VERSION_MONGO}" \
       nodejs \
       xvfb \
       yarn \
-  && apt-get install -y -t jessie-backports firefox \
   && apt-get clean \
   && ln -s /usr/bin/chromium /usr/bin/google-chrome \
+  && wget https://download-installer.cdn.mozilla.net/pub/firefox/releases/54.0/linux-x86_64/en-US/firefox-54.0.tar.bz2 \
+  && tar xvf firefox-54.0.tar.bz2 \
+  && mv $(which firefox) $(which firefox)-old \
+  && ln -s $(pwd)/firefox/firefox /usr/bin/firefox \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ test:
     - >
       set -e; 
       ./do_for_versions.bash '
-        docker run "scalableminds/sbt:$VERSION_TAG" bash -c "which sbt mongo nodejs";
+        docker run "scalableminds/sbt:$VERSION_TAG" bash -c "which sbt mongo nodejs firefox";
         export VERSION_TAG=$VERSION_TAG;
         docker-compose run example | grep "It works™";
         echo "show dbs" | docker-compose run example-mongo


### PR DESCRIPTION
* removes outdated firefox installations
* installs firefox-esr (version 52) first, to get all dependencies
* **installs firefox 54.0**

Steps to test:
* pull image
* run `firefox -V` in image

fixes #10