### PR TITLE
install pkg-config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN \
       nodejs \
       postgresql-client \
       yarn \
+      pkg-config \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
pkg-config needs to be available when installing https://github.com/stackgl/headless-gl which I want to use for node-based unit tests for glsl code 