### PR TITLE
Add further dependencies for headless-gl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN \
       nodejs \
       postgresql-client \
       yarn \
-      pkg-config \
+      pkg-config mesa-utils xvfb libgl1-mesa-dri libglapi-mesa libosmesa6 pkg-config x11proto-xext-dev xserver-xorg-dev libxext-dev libxi-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,9 @@ RUN \
       nodejs \
       postgresql-client \
       yarn \
-      pkg-config mesa-utils xvfb libgl1-mesa-dri libglapi-mesa libosmesa6 pkg-config x11proto-xext-dev xserver-xorg-dev libxext-dev libxi-dev \
+  # The following packages are necessary to run headless-gl
+  && apt-get install -y \
+      mesa-utils xvfb libgl1-mesa-dri libglapi-mesa libosmesa6 pkg-config x11proto-xext-dev xserver-xorg-dev libxext-dev libxi-dev
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
These dependencies are needed to make headless-gl work. I put the new dependencies in one line to make clear that these belong together. Does the dockerfile format support an inline comment within the apt-get install command?